### PR TITLE
Use Mumbai time in Clock

### DIFF
--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -8,7 +8,10 @@ export function Clock() {
 
   useEffect(() => {
     const updateTime = () => {
-      const now = new Date()
+      // Force the time to Asia/Kolkata (Mumbai) regardless of user timezone
+      const now = new Date(
+        new Date().toLocaleString('en-US', { timeZone: 'Asia/Kolkata' })
+      )
       const hours = now.getHours() % 12 || 12
       const minutes = now.getMinutes().toString().padStart(2, '0')
       const meridiem = now.getHours() >= 12 ? 'PM' : 'AM'


### PR DESCRIPTION
## Summary
- fix the Clock component so that it always displays time in the Mumbai timezone

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e29dcc0c832ba38f0c385cb11eea